### PR TITLE
Add syntax for array type in parameters

### DIFF
--- a/examples/factor.ja
+++ b/examples/factor.ja
@@ -9,7 +9,7 @@
 
 
 // factor num into table in fact[]
-procedure factor(int num, int fact)
+procedure factor(int num, int fact[])
     local int try = 0   // Attempted factor.
     local int i = 0     // Pointer to last factor in factor table.
     from (try = 0) && (num > 1) loop
@@ -45,7 +45,7 @@ procedure factor(int num, int fact)
     delocal int i = 0
     delocal int try = 0
 
-procedure zeroi(int i, int fact)
+procedure zeroi(int i, int fact[])
     from fact[i+1] = 0 loop
         i -= 1
     until i = 0

--- a/src/Jana/Ast.hs
+++ b/src/Jana/Ast.hs
@@ -68,7 +68,7 @@ data Expr
 -- Declaration
 data Vdecl
     = Scalar Type Ident SourcePos
-    | Array  Ident Integer SourcePos
+    | Array  Ident (Maybe Integer) SourcePos
     deriving (Eq)
 
 -- Main procedure
@@ -79,7 +79,7 @@ data ProcMain
 -- Procedure definition
 data Proc
     = Proc { procname  :: Ident
-           , params    :: [(Type, Ident)]   -- Zero or more
+           , params    :: [Vdecl]   -- Zero or more
            , body      :: [Stmt]
            }
     deriving (Eq)

--- a/src/Jana/ErrorMessages.hs
+++ b/src/Jana/ErrorMessages.hs
@@ -86,6 +86,16 @@ argumentError id expect actual = Message $
 arraySize :: Message
 arraySize = Message "Array size must be greater than or equal to one"
 
+arraySizeMissing :: Ident -> Message
+arraySizeMissing id = Message $
+  printf "Array size missing for variable `%s'" (ident id)
+
+arraySizeMismatch :: (PrintfArg a, PrintfArg b) => a -> b -> Message
+arraySizeMismatch exp actual = Message $
+  printf "Expecting array of size %d\n\
+         \           but got size %d"
+         exp actual
+
 divisionByZero :: Message
 divisionByZero = Message "Division by zero"
 

--- a/src/Jana/Format.hs
+++ b/src/Jana/Format.hs
@@ -71,7 +71,9 @@ formatVdecl (Scalar typ id _) =
   formatType typ <+> formatIdent id
 
 formatVdecl (Array id size _) =
-  text "int" <+> formatIdent id <> brackets (integer size)
+  text "int" <+> formatIdent id <> brackets (formatSize size)
+  where formatSize (Just x) = integer x
+        formatSize Nothing  = empty
 
 
 formatStmts = vcat . map formatStmt
@@ -167,9 +169,7 @@ formatMain (ProcMain vdecls body _) =
             formatStmts body)
 
 
-formatParams = commasep . map formatParam
-  where formatParam (typ, id) = formatType typ <+> formatIdent id
-
+formatParams = commasep . map formatVdecl
 
 formatProc proc =
   text "procedure" <+> formatIdent (procname proc) <>

--- a/src/Jana/Parser.hs
+++ b/src/Jana/Parser.hs
@@ -108,11 +108,11 @@ mainProcedure =
 
 vdecl :: Parser Vdecl
 vdecl =
-  do mytype <- atype
+  do pos    <- getPosition
+     mytype <- atype
      ident  <- identifier
-     pos    <- getPosition
      case mytype of
-       (Int _) ->     liftM2 (Array ident) (brackets integer) getPosition
+       (Int _) ->     liftM2 (Array ident) (brackets $ optionMaybe integer) (return pos)
                   <|> return (Scalar mytype ident pos)
        _       -> return $ Scalar mytype ident pos
 
@@ -120,7 +120,7 @@ procedure :: Parser Proc
 procedure =
   do reserved "procedure"
      name   <- identifier
-     params <- parens $ sepBy parameter comma
+     params <- parens $ sepBy vdecl comma
      stats  <- many1 statement
      return Proc { procname = name, params = params, body = stats }
 

--- a/src/Jana/Types.hs
+++ b/src/Jana/Types.hs
@@ -151,9 +151,10 @@ procEnvFromList = foldM insertProc emptyProcEnv
         ppos  Proc { procname = (Ident _ pos) } = pos
 
 makeIdentList :: Proc -> [Ident]
-makeIdentList (Proc {params = params}) = map paramToIdent params
+makeIdentList (Proc {params = params}) = map getVdeclIdent params
   where
-    paramToIdent (_, ident) = ident
+    getVdeclIdent (Scalar _ id _) = id
+    getVdeclIdent (Array id _ _)  = id
 
 checkDuplicateArgs :: [Ident] -> Bool
 checkDuplicateArgs []         = True

--- a/tests/errors/array-size-mismatch.ja
+++ b/tests/errors/array-size-mismatch.ja
@@ -1,0 +1,6 @@
+procedure foo(int x[3])
+    skip
+
+procedure main()
+    int x[4]
+    call foo(x)

--- a/tests/errors/array-size-missing.ja
+++ b/tests/errors/array-size-missing.ja
@@ -1,0 +1,3 @@
+procedure main()
+    int x[]
+    skip


### PR DESCRIPTION
Syntax:

```
procedure foo(int x[])
    if size(x) != 3 then
        error "x must be an array of length 3"
```

for accepting arrays of any length.

```
procedure foo(int x[3])
```

for accepting array of length 3 only.
