### PR TITLE
Added support for flags and specifically the modular int flag

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,24 +1,45 @@
 
 import System.Environment
+import Control.Monad
+import Data.List
 import Jana.Parser
 import Jana.Eval (runProgram)
+import Jana.Types (defaultOptions, EvalOptions(..))
 
-getFilename :: IO (Maybe String)
-getFilename =
+parseArgs :: IO (Maybe (String, EvalOptions))
+parseArgs =
   do args <- getArgs
-     case args of
-       [file] -> return $ Just file
-       _      -> return Nothing
+     (flags, file) <- return $ splitArgs args
+     case (checkFlags flags, checkFile file) of
+       (Left err, _) -> print err >> return Nothing
+       (_, Left err) -> print err >> return Nothing
+       (Right evalOptions, Right file) -> return $ Just (file, evalOptions)
 
-parseAndRun :: String -> IO ()
-parseAndRun filename =
+checkFile :: [String] -> Either String String
+checkFile [file] = Right file
+checkFile _ = Left "please provide a single file name"
+
+splitArgs :: [String] -> ([String], [String])
+splitArgs args =
+  partition (\arg -> (head arg) == '-') args
+
+checkFlags :: [String] -> Either String EvalOptions
+checkFlags = foldM addOption defaultOptions
+
+addOption :: EvalOptions -> String -> Either String EvalOptions
+addOption evalOptions "-m" =
+  return $ evalOptions{ modInt = True }
+addOption _ f = fail $ "invalid options: " ++ f
+
+parseAndRun :: String -> EvalOptions -> IO ()
+parseAndRun filename evalOptions =
   do ast <- parseFile filename
      case ast of
        Left err   -> print err
-       Right prog -> runProgram filename prog
+       Right prog -> runProgram filename prog evalOptions
 
 main :: IO ()
-main = do file <- getFilename
-          case file of
-            Nothing   -> print "usage: jana <file>"
-            Just file -> parseAndRun file
+main = do args <- parseArgs
+          case args of
+            Nothing            -> print "usage: jana <file>"
+            Just (file, flags) -> parseAndRun file flags

--- a/tests/errors/modular-integer.ja
+++ b/tests/errors/modular-integer.ja
@@ -1,0 +1,12 @@
+procedure main()
+  int a
+  // This should be positive no matter what
+  a += 2147483648
+  // This should be negative if modular
+  a += 10
+
+  if (a > 0) then
+    error "Program has been run without modular flag"
+  else
+    error "Program has been run with modular flag"
+  fi 1


### PR DESCRIPTION
Closes #9 

You can now give jana the option "-m", if you want integers to be 32-bit modular. Also added a default way of adding options through the new type `EvalOptions', in Jana/Types.hs.

Unknown options are not allowed, but multiples of the same option is allowed.
