### PR TITLE
Disambiguated `<>` to `Text.PrettyPrint.<>` by hiding `Prelude.<>`.

### DIFF
--- a/src/Jana/Format.hs
+++ b/src/Jana/Format.hs
@@ -1,6 +1,6 @@
 module Jana.Format where
 
-import Prelude hiding (GT, LT, EQ)
+import Prelude hiding (GT, LT, EQ, (<>))
 import Data.List (intersperse)
 import Text.PrettyPrint
 import qualified Data.Map as Map


### PR DESCRIPTION
With this change I am able to compile your sources in 2020.

I ran the Fibonacci example as a test.